### PR TITLE
add preStop delay, termination grace per container, anti-affinity 

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ List the contents of the bucket:
     nginx:
       image: nginx
       tag: latest
+      enableNginxAntiAffinityRequired: false
   ```
 
 - You can apply additional configurations to override the configuration at

--- a/helm/templates/external-scaler-deployment.yaml
+++ b/helm/templates/external-scaler-deployment.yaml
@@ -18,12 +18,18 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
+            - weight: 10
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
                     cwm-worker-deployment: minio
+            - weight: 20
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: minio-external-scaler
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.externalscaler.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/external-scaler-deployment.yaml
+++ b/helm/templates/external-scaler-deployment.yaml
@@ -18,10 +18,12 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  cwm-worker-deployment: minio
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.externalscaler.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/external-scaler-deployment.yaml
+++ b/helm/templates/external-scaler-deployment.yaml
@@ -13,7 +13,15 @@ spec:
     metadata:
       labels:
         app: minio-external-scaler
+        cwm-worker-deployment: minio
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.externalscaler.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/external-scaler-deployment.yaml
+++ b/helm/templates/external-scaler-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: minio-external-scaler
     spec:
       dnsPolicy: ClusterFirst
-      terminationGracePeriodSeconds: {{ $.Values.minio.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $.Values.minio.externalscaler.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false
       {{- if $.Values.minio.nodeSelector }}
       nodeSelector: {{ $.Values.minio.nodeSelector | nindent 8 }}
@@ -26,6 +26,7 @@ spec:
       containers:
       - name: minio-external-scaler
         image: {{ $.Values.minio.externalscaler.image }}
+        lifecycle: {preStop: {exec: {command: ["sleep", {{ $.Values.minio.externalscaler.preStopDelaySeconds | quote }}]}}}
         imagePullPolicy: {{ $.Values.minio.externalscaler.imagePullPolicy }}
         resources: {{ toYaml $.Values.minio.externalscaler.resources | nindent 10 }}
         env:

--- a/helm/templates/logger-deployment.yaml
+++ b/helm/templates/logger-deployment.yaml
@@ -20,10 +20,12 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  cwm-worker-deployment: minio
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.metricsLogger.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/logger-deployment.yaml
+++ b/helm/templates/logger-deployment.yaml
@@ -20,12 +20,24 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
+            - weight: 10
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
                     cwm-worker-deployment: minio
+            - weight: 20
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: minio-logger
+            - weight: 30
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: minio-server
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.metricsLogger.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/logger-deployment.yaml
+++ b/helm/templates/logger-deployment.yaml
@@ -13,9 +13,17 @@ spec:
     metadata:
       labels:
         app: minio-logger
+        cwm-worker-deployment: minio
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/logger-configmap.yaml") . | sha256sum }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.metricsLogger.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/logger-deployment.yaml
+++ b/helm/templates/logger-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/logger-configmap.yaml") . | sha256sum }}
     spec:
       dnsPolicy: ClusterFirst
-      terminationGracePeriodSeconds: {{ $.Values.minio.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $.Values.minio.metricsLogger.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false
       {{- if $.Values.minio.nodeSelector }}
       nodeSelector: {{ $.Values.minio.nodeSelector | nindent 8 }}
@@ -28,6 +28,7 @@ spec:
       containers:
       - name: logger
         image: {{ $.Values.minio.metricsLogger.image }}
+        lifecycle: {preStop: {exec: {command: ["sleep", {{ $.Values.minio.metricsLogger.preStopDelaySeconds | quote }}]}}}
         imagePullPolicy: {{ $.Values.minio.metricsLogger.imagePullPolicy }}
         resources: {{ toYaml $.Values.minio.metricsLogger.resources | nindent 10 }}
         volumeMounts:

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -27,12 +27,18 @@ spec:
                   app: minio-nginx
           {{ end }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
+            - weight: 10
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
                     cwm-worker-deployment: minio
+            - weight: 20
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: minio-nginx
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.nginx.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -27,10 +27,12 @@ spec:
                   app: minio-nginx
           {{ end }}
           preferredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  cwm-worker-deployment: minio
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.nginx.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -13,16 +13,24 @@ spec:
     metadata:
       labels:
         app: minio-nginx
+        cwm-worker-deployment: minio
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/nginx-hostnames-configmap.yaml") . | sha256sum }}
     spec:
       affinity:
         podAntiAffinity:
+          {{ if $.Values.minio.nginx.enableNginxAntiAffinityRequired }}
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: kubernetes.io/hostname
               labelSelector:
                 matchLabels:
                   app: minio-nginx
+          {{ end }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.nginx.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -24,7 +24,7 @@ spec:
                 matchLabels:
                   app: minio-nginx
       dnsPolicy: ClusterFirst
-      terminationGracePeriodSeconds: {{ $.Values.minio.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $.Values.minio.nginx.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false
       {{- if $.Values.minio.nodeSelector }}
       nodeSelector: {{ $.Values.minio.nodeSelector | nindent 8 }}
@@ -35,6 +35,7 @@ spec:
       containers:
       - name: nginx
         image: {{ $.Values.minio.nginx.image }}:{{ $.Values.minio.nginx.tag | default $.Chart.AppVersion }}
+        lifecycle: {preStop: {exec: {command: ["sleep", {{ $.Values.minio.nginx.preStopDelaySeconds | quote }}]}}}
         imagePullPolicy: {{ $.Values.minio.imagePullPolicy }}
         env:
           - name: HOSTNAMES_DIR

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -18,10 +18,12 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  cwm-worker-deployment: minio
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - name: http
         image: {{ $.Values.minio.image }}:{{ $.Values.minio.tag | default $.Chart.AppVersion }}
+        lifecycle: {preStop: {exec: {command: ["sleep", {{ $.Values.minio.preStopDelaySeconds | quote }}]}}}
         imagePullPolicy: {{ $.Values.minio.imagePullPolicy }}
         env:
         {{- $domains := list }}

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -18,12 +18,24 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
+            - weight: 10
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
                     cwm-worker-deployment: minio
+            - weight: 20
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: minio-server
+            - weight: 30
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: minio-logger
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -13,7 +13,15 @@ spec:
     metadata:
       labels:
         app: minio-server
+        cwm-worker-deployment: minio
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  cwm-worker-deployment: minio
       dnsPolicy: ClusterFirst
       terminationGracePeriodSeconds: {{ $.Values.minio.terminationGracePeriodSeconds }}
       automountServiceAccountToken: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -229,6 +229,7 @@ minio:
       rollingUpdate:
         maxUnavailable: 0
         maxSurge: 1
+    enableNginxAntiAffinityRequired: true
     image: ghcr.io/cloudwebmanage/cwm-worker-deployment-minio/minio-nginx
     terminationGracePeriodSeconds: 5
     preStopDelaySeconds: 2

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,7 @@ minio:
   replicas: 1
   revisionHistoryLimit: 2
   terminationGracePeriodSeconds: 5
+  preStopDelaySeconds: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -95,6 +96,8 @@ minio:
     enabled: false
     image: ghcr.io/cloudwebmanage/cwm-keda-external-scaler
     imagePullPolicy: IfNotPresent
+    terminationGracePeriodSeconds: 5
+    preStopDelaySeconds: 2
     resources:
       requests:
         cpu: "20m"
@@ -135,6 +138,8 @@ minio:
     enable: true
     image: ghcr.io/cloudwebmanage/cwm-worker-logger/cwm-worker-logger
     imagePullPolicy: IfNotPresent
+    terminationGracePeriodSeconds: 5
+    preStopDelaySeconds: 2
     resources:
       requests:
         cpu: "20m"
@@ -225,6 +230,8 @@ minio:
         maxUnavailable: 0
         maxSurge: 1
     image: ghcr.io/cloudwebmanage/cwm-worker-deployment-minio/minio-nginx
+    terminationGracePeriodSeconds: 5
+    preStopDelaySeconds: 2
     tag: ""
     resources:
       requests:


### PR DESCRIPTION
following research in CloudWebManage/cwm-worker-cluster#196:

* add configurable preStop hook for all container to allow to add a delay before termination regardless of how each container handles SIGTERM
* change the terminationGracePeriodSeconds to be configurable for each pod
* added anti affinity which prefers scheduling of each pod on a different node - reducing the harm in case of node failure