### PR TITLE
[CWM-215] Configure LOG_LEVEL for external scaler.

### DIFF
--- a/helm/templates/external-scaler-deployment.yaml
+++ b/helm/templates/external-scaler-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         resources: {{ toYaml $.Values.minio.externalscaler.resources | nindent 10 }}
         env:
         - name: LOG_LEVEL
-          value: {{ $.Values.minio.metricsLogger.LOG_LEVEL | quote }}
+          value: {{ $.Values.minio.externalscaler.LOG_LEVEL | quote }}
         - name: CWM_REDIS_HOST
           value: {{ $.Values.minio.metricsLogger.REDIS_HOST | quote }}
         - name: CWM_REDIS_PORT

--- a/helm/templates/external-scaler-deployment.yaml
+++ b/helm/templates/external-scaler-deployment.yaml
@@ -29,6 +29,8 @@ spec:
         imagePullPolicy: {{ $.Values.minio.externalscaler.imagePullPolicy }}
         resources: {{ toYaml $.Values.minio.externalscaler.resources | nindent 10 }}
         env:
+        - name: LOG_LEVEL
+          value: {{ $.Values.minio.metricsLogger.LOG_LEVEL | quote }}
         - name: CWM_REDIS_HOST
           value: {{ $.Values.minio.metricsLogger.REDIS_HOST | quote }}
         - name: CWM_REDIS_PORT

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -95,6 +95,7 @@ minio:
     enabled: false
     image: ghcr.io/cloudwebmanage/cwm-keda-external-scaler
     imagePullPolicy: IfNotPresent
+    LOG_LEVEL: "warn"
     resources:
       requests:
         cpu: "20m"


### PR DESCRIPTION
Configure `LOG_LEVEL` for external scaler.

- Use `LOG_LEVEL` of metrics logger for scaler deployment.
- Resolves https://github.com/CloudWebManage/cwm-worker-cluster/issues/215

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>